### PR TITLE
Login redirect and shown requirements

### DIFF
--- a/app/static/log_in_page_stylesheet.css
+++ b/app/static/log_in_page_stylesheet.css
@@ -41,9 +41,10 @@ body {
 
 .email, .password, .UserName, .Email {
     margin: 5px;
-    min-height: 100px;
+    min-height: 75px;
     display: flex;
     flex-direction: column;
+    width: 100%;
 }
 
 .email p, .password p, .UserName p, .Email p {
@@ -104,15 +105,6 @@ input {
     width: 100%;
 }
 
-
-.Email, .password, .UserName {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    margin: 5px 0;
-
-}
-
 .signup-popup {
     margin-top: 20px;
     cursor: pointer;
@@ -164,4 +156,21 @@ input {
     background-color: #d4edda;
     color: #10832b;
     border: 1px solid #355d3e
+}
+
+.home-redirect {
+    position:absolute;
+    top: 20px;
+    left: 20px;
+    text-decoration: none;
+    color: #343738;
+    font-weight: bold;
+}
+
+.helper-text {
+    color: #6c757d;
+    font-size: 0.75rem;
+    margin-top: 4px;
+    line-height: 1.2;
+    word-wrap: break-word;
 }

--- a/app/templates/log_in_page.html
+++ b/app/templates/log_in_page.html
@@ -10,6 +10,7 @@
 
 <body>
     <div class="content">
+        <a href="{{ url_for('main.index') }}" class="home-redirect">&#x21D0; Home</a>
         <div class="greetings">
             <div class="logo-container">
                 <div class="logo"></div>
@@ -76,6 +77,10 @@
                 </div>
                  <div class="password">
                     <p>Password</p>
+
+                    <div class="helper-text">
+                        Password must be 8+ chars, have 1 uppercase, 1 lowercase, 1 number, and 1 special char.
+                    </div>
                     {{ signup_form.password(placeholder="••••••••") }}
                     {% for error in signup_form.password.errors %}
                         <div class="error-text">{{ error }}</div>


### PR DESCRIPTION
Modification to log_in_page.html:
- Login page can now redirect to the index page using url_for, Additionally added a unicode arrow with this.
- signup form now displays the password requirement above its input box

Modification to log_in_page.css:
- new classes: home-redirect and helper-text
- home-redirect modifies redirect placement to the top left corner of the of the page
- helper text modifies the font for the requirements.
- adjusted the spacing between the username/email/password in both forms.
- found that there were duplicated styling for the ones mentioned. Got rid of these and condense it to only one block of styling!
